### PR TITLE
fix issue with using compset longname in cesm testing

### DIFF
--- a/diag_manager/diag_data.F90
+++ b/diag_manager/diag_data.F90
@@ -66,7 +66,7 @@ use platform_mod
   ! Specify storage limits for fixed size tables used for pointers, etc.
   INTEGER, PARAMETER :: MAX_NAME_LENGTH=256
   INTEGER, PARAMETER :: MAX_FILENAME_LENGTH=512
-  
+
   INTEGER, PARAMETER :: MAX_FIELDS_PER_FILE = 300 !< Maximum number of fields per file.
   INTEGER, PARAMETER :: DIAG_OTHER = 0
   INTEGER, PARAMETER :: DIAG_OCEAN = 1

--- a/diag_manager/diag_data.F90
+++ b/diag_manager/diag_data.F90
@@ -64,6 +64,9 @@ use platform_mod
   PUBLIC
 
   ! Specify storage limits for fixed size tables used for pointers, etc.
+  INTEGER, PARAMETER :: MAX_NAME_LENGTH=256
+  INTEGER, PARAMETER :: MAX_FILENAME_LENGTH=512
+  
   INTEGER, PARAMETER :: MAX_FIELDS_PER_FILE = 300 !< Maximum number of fields per file.
   INTEGER, PARAMETER :: DIAG_OTHER = 0
   INTEGER, PARAMETER :: DIAG_OCEAN = 1
@@ -102,7 +105,7 @@ use platform_mod
      REAL :: miss, miss_pack
      LOGICAL :: miss_present, miss_pack_present
      INTEGER :: tile_count
-     character(len=128)      :: fieldname !< Fieldname
+     character(len=MAX_NAME_LENGTH)      :: fieldname !< Fieldname
   END TYPE diag_fieldtype
 
   !> @brief Attribute type for diagnostic fields
@@ -111,7 +114,7 @@ use platform_mod
      INTEGER             :: type !< Data type of attribute values (NF_INT, NF_FLOAT, NF_CHAR)
      INTEGER             :: len !< Number of values in attribute, or if a character string then
                                 !! length of the string.
-     CHARACTER(len=128)  :: name !< Name of the attribute
+     CHARACTER(len=MAX_NAME_LENGTH)  :: name !< Name of the attribute
      CHARACTER(len=1280) :: catt !< Character string to hold character value of attribute
      REAL, allocatable, DIMENSION(:)    :: fatt !< REAL array to hold value of REAL attributes
      INTEGER, allocatable, DIMENSION(:) :: iatt !< INTEGER array to hold value of INTEGER attributes
@@ -133,8 +136,8 @@ use platform_mod
   !> @brief Type to define the diagnostic files that will be written as defined by the diagnostic table.
   !> @ingroup diag_data_mod
   TYPE file_type
-     CHARACTER(len=128) :: name !< Name of the output file.
-     CHARACTER(len=128) :: long_name
+     CHARACTER(len=MAX_NAME_LENGTH) :: name !< Name of the output file.
+     CHARACTER(len=MAX_NAME_LENGTH) :: long_name
      INTEGER, DIMENSION(max_fields_per_file) :: fields
      INTEGER :: num_fields
      INTEGER :: output_freq
@@ -173,8 +176,8 @@ use platform_mod
   !> @brief Type to hold the input field description
   !> @ingroup diag_data_mod
   TYPE input_field_type
-     CHARACTER(len=128) :: module_name, field_name, long_name, units
-     CHARACTER(len=256) :: standard_name
+     CHARACTER(len=MAX_NAME_LENGTH) :: module_name, field_name, long_name, units
+     CHARACTER(len=MAX_FILENAME_LENGTH) :: standard_name
      CHARACTER(len=64) :: interp_method
      INTEGER, DIMENSION(3) :: axes
      INTEGER :: num_axes
@@ -202,7 +205,7 @@ use platform_mod
   TYPE output_field_type
      INTEGER :: input_field !< index of the corresponding input field in the table
      INTEGER :: output_file !< index of the output file in the table
-     CHARACTER(len=128) :: output_name
+     CHARACTER(len=MAX_NAME_LENGTH) :: output_name
      LOGICAL :: time_average !< true if the output field is averaged over time interval
      LOGICAL :: time_rms !< true if the output field is the rms.  If true, then time_average is also
      LOGICAL :: static
@@ -257,19 +260,19 @@ use platform_mod
   !> @brief Type to hold the diagnostic axis description.
   !> @ingroup diag_data_mod
   TYPE diag_axis_type
-     CHARACTER(len=128) :: name
-     CHARACTER(len=256) :: units, long_name
+     CHARACTER(len=MAX_NAME_LENGTH) :: name
+     CHARACTER(len=MAX_FILENAME_LENGTH) :: units, long_name
      CHARACTER(len=1) :: cart_name
      REAL, DIMENSION(:), POINTER :: data
      INTEGER, DIMENSION(MAX_SUBAXES) :: start
      INTEGER, DIMENSION(MAX_SUBAXES) :: end
-     CHARACTER(len=128), DIMENSION(MAX_SUBAXES) :: subaxis_name
+     CHARACTER(len=MAX_NAME_LENGTH), DIMENSION(MAX_SUBAXES) :: subaxis_name
      INTEGER :: length, direction, edges, set, shift
      TYPE(domain1d) :: Domain
      TYPE(domain2d) :: Domain2
      TYPE(domain2d), dimension(MAX_SUBAXES) :: subaxis_domain2
      type(domainUG) :: DomainUG
-     CHARACTER(len=128) :: aux, req
+     CHARACTER(len=MAX_NAME_LENGTH) :: aux, req
      INTEGER :: tile_count
      TYPE(diag_atttype), allocatable, dimension(:) :: attributes !< Array to hold user definable attributes
      INTEGER :: num_attributes !< Number of defined attibutes
@@ -278,8 +281,8 @@ use platform_mod
 
   !> @ingroup diag_data_mod
   TYPE diag_global_att_type
-     CHARACTER(len=128)   :: grid_type='regular'
-     CHARACTER(len=128)   :: tile_name='N/A'
+     CHARACTER(len=MAX_NAME_LENGTH)   :: grid_type='regular'
+     CHARACTER(len=MAX_NAME_LENGTH)   :: tile_name='N/A'
   END TYPE diag_global_att_type
 
 ! Include variable "version" to be written to log file.
@@ -354,7 +357,7 @@ use platform_mod
                                     !! diag_manager_init call, then same as base_time
   TYPE(time_type) :: base_time
   INTEGER :: base_year, base_month, base_day, base_hour, base_minute, base_second
-  CHARACTER(len = 256):: global_descriptor
+  CHARACTER(len = MAX_FILENAME_LENGTH):: global_descriptor
 
   ! <!-- ALLOCATABLE variables -->
   TYPE(file_type), SAVE, ALLOCATABLE :: files(:)

--- a/diag_manager/diag_table.F90
+++ b/diag_manager/diag_table.F90
@@ -255,7 +255,8 @@ MODULE diag_table_mod
   USE constants_mod, ONLY: SECONDS_PER_HOUR, SECONDS_PER_MINUTE
 
   USE diag_data_mod, ONLY: global_descriptor, base_time, base_year, base_month, base_day, base_hour, base_minute, &
-                         & base_second, DIAG_OTHER, DIAG_OCEAN, DIAG_ALL, coord_type, append_pelist_name, pelist_name
+       & base_second, DIAG_OTHER, DIAG_OCEAN, DIAG_ALL, coord_type, append_pelist_name, pelist_name, &
+       MAX_NAME_LENGTH, MAX_FILENAME_LENGTH
   USE diag_util_mod, ONLY: init_file, check_duplicate_output_fields, init_input_field, init_output_field
 
   IMPLICIT NONE
@@ -266,7 +267,7 @@ MODULE diag_table_mod
   !> Private type to hold field information for the diag table
   !> @ingroup diag_table_mod
   TYPE field_description_type
-     CHARACTER(len=128) :: module_name, field_name, output_name, file_name
+     CHARACTER(len=MAX_NAME_LENGTH) :: module_name, field_name, output_name, file_name
      CHARACTER(len=50) :: time_sampling
      CHARACTER(len=50) :: time_method
      CHARACTER(len=50) :: spatial_ops
@@ -285,10 +286,10 @@ MODULE diag_table_mod
      INTEGER :: iOutput_freq_units
      INTEGER :: iNew_file_freq_units
      INTEGER :: iFile_duration_units
-     CHARACTER(len=128) :: file_name
+     CHARACTER(len=MAX_FILENAME_LENGTH) :: file_name
      CHARACTER(len=10) :: output_freq_units
      CHARACTER(len=10) :: time_units
-     CHARACTER(len=128) :: long_name
+     CHARACTER(len=MAX_NAME_LENGTH) :: long_name
      CHARACTER(len=10) :: new_file_freq_units
      CHARACTER(len=25) :: start_time_s
      CHARACTER(len=10) :: file_duration_units
@@ -323,7 +324,7 @@ CONTAINS
     CHARACTER(len=*), INTENT(out), OPTIONAL :: err_msg !< Error message corresponding to the
                                                        !! <TT>istat</TT> return value.
 
-    INTEGER, PARAMETER :: DT_LINE_LENGTH = 256
+    INTEGER, PARAMETER :: DT_LINE_LENGTH = MAX_FILENAME_LENGTH
 
     INTEGER :: stdlog_unit !< Fortran file unit number for the stdlog file.
     INTEGER :: record_len !< String length of the diag_table line read in.
@@ -804,7 +805,7 @@ CONTAINS
 
   !> @brief Fixes the file name for use with diagnostic file and field initializations.
   !! @return Character(len=128) fix_file_name
-  PURE CHARACTER(len=128) FUNCTION fix_file_name(file_name_string)
+  PURE CHARACTER(len=MAX_FILENAME_LENGTH) FUNCTION fix_file_name(file_name_string)
     CHARACTER(len=*), INTENT(IN) :: file_name_string !< String containing the file name from the <TT>diag_table</TT>.
 
     INTEGER :: file_name_len

--- a/diag_manager/diag_util.F90
+++ b/diag_manager/diag_util.F90
@@ -2288,15 +2288,22 @@ END SUBROUTINE check_bounds_are_exact_dynamic
     character(len=*), intent(in) :: filename
     character(len=2) :: first_fms_percent
     integer :: i
-
-    do i=1,9
-       write(first_fms_percent,"('%',i1)") i
-       find_first_fms_percent = INDEX(filename, first_fms_percent)
-       if (find_first_fms_percent > 0) then
-          exit
+    integer :: first_percent
+    integer :: first_percent_loc
+    
+    first_percent = INDEX(filename, '%1')
+    do i=2,9
+       write(first_fms_percent,"('%',i1)") i 
+       first_percent_loc = INDEX(filename, first_fms_percent)
+       if (first_percent_loc > 0) then
+          if (first_percent == 0) then
+             first_percent = first_percent_loc
+          else
+             first_percent = min(first_percent, first_percent_loc)
+          endif
        endif
     enddo
-
+    find_first_fms_percent = first_percent
   end function find_first_fms_percent
 
 

--- a/diag_manager/diag_util.F90
+++ b/diag_manager/diag_util.F90
@@ -50,7 +50,7 @@ use,intrinsic :: iso_c_binding, only: c_double,c_float,c_int64_t, &
        & debug_diag_manager, flush_nc_files, output_field_type, max_field_attributes, max_file_attributes,&
        & file_type, prepend_date, region_out_use_alt_value, GLO_REG_VAL, GLO_REG_VAL_ALT,&
        & DIAG_FIELD_NOT_FOUND, diag_init_time, diag_atttype
-  USE diag_data_mod, ONLY: fileobjU, fileobj, fnum_for_domain, fileobjND
+  USE diag_data_mod, ONLY: fileobjU, fileobj, fnum_for_domain, fileobjND, MAX_NAME_LENGTH, MAX_FILENAME_LENGTH
   USE diag_axis_mod, ONLY: get_diag_axis_data, get_axis_global_length, get_diag_axis_cart,&
        & get_domain1d, get_domain2d, diag_subaxes_init, diag_axis_init, get_diag_axis, get_axis_aux,&
        & get_axes_shift, get_diag_axis_name, get_diag_axis_domain_name, get_domainUG, &
@@ -152,11 +152,11 @@ CONTAINS
     REAL, ALLOCATABLE :: subaxis_x(:) !< containing local coordinates in x,y,z axes
     REAL, ALLOCATABLE :: subaxis_y(:) !< containing local coordinates in x,y,z axes
     REAL, ALLOCATABLE :: subaxis_z(:) !< containing local coordinates in x,y,z axes
-    CHARACTER(len=128) :: msg
+    CHARACTER(len=MAX_NAME_LENGTH) :: msg
     INTEGER :: ishift, jshift
     INTEGER :: grv !< Value used to determine if the region defined in the diag_table is for the whole
                    !! axis, or a sub-axis
-    CHARACTER(len=128), DIMENSION(2) :: axis_domain_name
+    CHARACTER(len=MAX_NAME_LENGTH), DIMENSION(2) :: axis_domain_name
 
     !initilization for local output
     ! initially out of (lat/lon/depth) range
@@ -429,7 +429,7 @@ CONTAINS
     INTEGER, DIMENSION(3) :: gstart_indx !< global start and end indices of output domain in 3 axes
     INTEGER, DIMENSION(3) :: gend_indx !< global start and end indices of output domain in 3 axes
     CHARACTER(len=1) :: cart
-    CHARACTER(len=128) :: msg
+    CHARACTER(len=MAX_NAME_LENGTH) :: msg
 !----------
 !ug support
     integer :: vert_dim_num
@@ -648,13 +648,13 @@ CONTAINS
     LOGICAL, OPTIONAL, INTENT(in) :: dynamic !< <TT>.TRUE.</TT> if field is not static.
 
     ! ---- local vars
-    CHARACTER(len=256) :: lmodule, lfield, lname, lunits
+    CHARACTER(len=MAX_FILENAME_LENGTH) :: lmodule, lfield, lname, lunits
     CHARACTER(len=64)  :: lmissval, lmin, lmax
     CHARACTER(len=8)   :: numaxis, timeaxis
     INTEGER :: i
     REAL :: missing_value_use !< Local copy of missing_value
     REAL, DIMENSION(2) :: range_use !< Local copy of range
-    CHARACTER(len=256) :: axis_name, axes_list
+    CHARACTER(len=MAX_FILENAME_LENGTH) :: axis_name, axes_list
 
     IF ( .NOT.do_diag_field_log ) RETURN
     IF ( mpp_pe().NE.mpp_root_pe() ) RETURN
@@ -848,7 +848,7 @@ SUBROUTINE check_out_of_bounds(out_num, diag_field_id, err_msg)
   CHARACTER(len=*), INTENT(out) :: err_msg !< Return status of <TT>check_out_of_bounds</TT>.  An empty
                                            !! error string indicates the x, y, and z indices are not outside the
 
-  CHARACTER(len=128) :: error_string1, error_string2
+  CHARACTER(len=MAX_NAME_LENGTH) :: error_string1, error_string2
   LOGICAL :: out_of_bounds = .true.
   TYPE (fmsDiagIbounds_type) :: array_bounds
   associate (buff_bounds => output_fields(out_num)%buff_bounds)
@@ -882,7 +882,7 @@ SUBROUTINE fms_diag_check_out_of_bounds_r4(ofb, bounds, output_name, module_name
   CHARACTER(len=*), INTENT(inout) :: err_msg !< Return status of <TT>check_out_of_bounds</TT>.  An empty
                                            !! error string indicates the x, y, and z indices are not outside the
 
-  CHARACTER(len=128) :: error_string1, error_string2
+  CHARACTER(len=MAX_NAME_LENGTH) :: error_string1, error_string2
   LOGICAL :: out_of_bounds = .true.
   TYPE (fmsDiagIbounds_type) :: array_bounds
 
@@ -914,7 +914,7 @@ SUBROUTINE fms_diag_check_out_of_bounds_r8(ofb, bounds, output_name, module_name
   CHARACTER(len=*), INTENT(out) :: err_msg !< Return status of <TT>check_out_of_bounds</TT>.  An empty
                                            !! error string indicates the x, y, and z indices are not outside the
 
-  CHARACTER(len=128) :: error_string1, error_string2
+  CHARACTER(len=MAX_NAME_LENGTH) :: error_string1, error_string2
   LOGICAL :: out_of_bounds = .true.
   TYPE (fmsDiagIbounds_type) :: array_bounds  !<A bounding box holdstore the current bounds ofb
 
@@ -954,7 +954,7 @@ SUBROUTINE fms_diag_check_bounds_are_exact_dynamic(current_bounds, bounds, outpu
   !! An empty error string indicates the x, y, and z indices are
   !!     equal to the buffer array boundaries.
 
-  CHARACTER(len=128) :: error_string1, error_string2
+  CHARACTER(len=MAX_NAME_LENGTH) :: error_string1, error_string2
   LOGICAL :: do_check
   LOGICAL :: lims_not_exact
 
@@ -1048,7 +1048,7 @@ END SUBROUTINE check_bounds_are_exact_dynamic
     CHARACTER(len=*), INTENT(out) :: err_msg !< The return status, which is set to non-empty message
                                                !! if the check fails.
 
-    CHARACTER(len=128)  :: error_string1, error_string2
+    CHARACTER(len=MAX_NAME_LENGTH)  :: error_string1, error_string2
     LOGICAL :: lims_not_exact
 
     err_msg = ''
@@ -1086,7 +1086,7 @@ END SUBROUTINE check_bounds_are_exact_dynamic
                              !! previously been registered, this new file
                              !! contained differences from the previous.
     REAL, DIMENSION(1) :: tdata
-    CHARACTER(len=128) :: time_units_str
+    CHARACTER(len=MAX_NAME_LENGTH) :: time_units_str
 
     ! Check if this file has already been defined
     same_file_err=.FALSE. ! To indicate that if this file was previously defined
@@ -1249,7 +1249,7 @@ END SUBROUTINE check_bounds_are_exact_dynamic
     TYPE(time_type), INTENT(in) :: init_time !< Initial time use for the synchronization.
     CHARACTER(len=*), OPTIONAL, INTENT(out) :: err_msg !< Return error message
 
-    CHARACTER(len=128) :: msg
+    CHARACTER(len=MAX_NAME_LENGTH) :: msg
 
     IF ( PRESENT(err_msg) ) err_msg = ''
 
@@ -1281,7 +1281,7 @@ END SUBROUTINE check_bounds_are_exact_dynamic
                                                        !! An empty string indicates the next output
                                                        !! time was found successfully.
 
-    CHARACTER(len=128) :: error_message_local
+    CHARACTER(len=MAX_NAME_LENGTH) :: error_message_local
 
     IF ( PRESENT(err_msg) ) err_msg = ''
     error_message_local = ''
@@ -1430,9 +1430,9 @@ END SUBROUTINE check_bounds_are_exact_dynamic
     REAL :: pow_value
     INTEGER :: grv !< Value used to determine if the region defined in the diag_table is for the whole
                    !! axis, or a sub-axis
-    CHARACTER(len=128) :: error_msg
+    CHARACTER(len=MAX_NAME_LENGTH) :: error_msg
     CHARACTER(len=50) :: t_method
-    character(len=256) :: tmp_name
+    character(len=MAX_FILENAME_LENGTH) :: tmp_name
 
     ! Value to use to determine if a region is to be output on the full axis, or sub-axis
     ! get the value to compare to determine if writing full axis data
@@ -1726,10 +1726,10 @@ END SUBROUTINE check_bounds_are_exact_dynamic
     INTEGER, ALLOCATABLE  :: axesc(:) ! indices if compressed axes associated with the field
     LOGICAL :: time_ops, aux_present, match_aux_name, req_present, match_req_fields
     CHARACTER(len=7) :: avg_name = 'average'
-    CHARACTER(len=128) :: time_units, timeb_units, avg, error_string, filename, aux_name, req_fields, fieldname
-    CHARACTER(len=128) :: suffix, base_name
+    CHARACTER(len=MAX_NAME_LENGTH) :: time_units, timeb_units, avg, error_string, filename, aux_name, req_fields, fieldname
+    CHARACTER(len=MAX_NAME_LENGTH) :: suffix, base_name
     CHARACTER(len=32) :: time_name, timeb_name,time_longname, timeb_longname, cart_name
-    CHARACTER(len=256) :: fname
+    CHARACTER(len=MAX_FILENAME_LENGTH) :: fname
     CHARACTER(len=24) :: start_date
     TYPE(domain1d) :: domain
     TYPE(domain2d) :: domain2
@@ -2137,9 +2137,9 @@ END SUBROUTINE check_bounds_are_exact_dynamic
 
   !> @brief This function determines a string based on current time.
   !!     This string is used as suffix in output file name
-  !! @return Character(len=128) get_time_string
-  CHARACTER(len=128) FUNCTION get_time_string(filename, current_time)
-    CHARACTER(len=128), INTENT(in) :: filename !< File name.
+  !! @return Character(len=MAX_NAME_LENGTH) get_time_string
+  CHARACTER(len=MAX_NAME_LENGTH) FUNCTION get_time_string(filename, current_time)
+    CHARACTER(len=MAX_NAME_LENGTH), INTENT(in) :: filename !< File name.
     TYPE(time_type), INTENT(in) :: current_time !< Current model time.
 
     INTEGER :: yr1 !< get from current time
@@ -2170,12 +2170,19 @@ END SUBROUTINE check_bounds_are_exact_dynamic
     CHARACTER(len=20) :: hr !< string of current time (output)
     CHARACTER(len=20) :: mi !< string of current time (output)
     CHARACTER(len=20) :: sc !< string of current time (output)
-    CHARACTER(len=128) :: filetail
-
+    CHARACTER(len=MAX_NAME_LENGTH) :: filetail
+    character(len=2) :: first_fms_percent
+    
     format = '("-",i*.*)'
     CALL get_date(current_time, yr1, mo1, dy1, hr1, mi1, sc1)
     len = LEN_TRIM(filename)
-    first_percent = INDEX(filename, '%')
+    do i=1,9
+       write(first_fms_percent,"('%',i1)") i 
+       first_percent = INDEX(filename, first_fms_percent)
+       if (first_percent > 0) then
+          exit
+       endif
+    enddo
     filetail = filename(first_percent:len)
     ! compute year string
     position = INDEX(filetail, 'yr')
@@ -2511,8 +2518,8 @@ END SUBROUTINE check_bounds_are_exact_dynamic
     CHARACTER(len=*), INTENT(out), OPTIONAL :: err_msg !< Error message.  If empty, then no duplicates found.
 
     INTEGER :: i, j, tmp_file
-    CHARACTER(len=128) :: tmp_name
-    CHARACTER(len=256) :: err_msg_local
+    CHARACTER(len=MAX_NAME_LENGTH) :: tmp_name
+    CHARACTER(len=MAX_FILENAME_LENGTH) :: err_msg_local
 
     IF ( PRESENT(err_msg) ) err_msg=''
     ! Do the checking when more than 1 output_fileds present

--- a/mpp/include/mpp_io_misc.inc
+++ b/mpp/include/mpp_io_misc.inc
@@ -142,7 +142,7 @@
 !external handles to netCDF units are saved from maxunits+1:2*maxunits
 !starts at NULLUNIT=-1, used by non-participant PEs in single-threaded I/O
 ! Mofified to allow negative unit numbers as returned from the newunit method.
-      allocate( mpp_file(-maxunits:2*maxunits) ) 
+      allocate( mpp_file(-maxunits:2*maxunits) )
       mpp_file(:)%name   = ' '
       mpp_file(:)%action    = -1
       mpp_file(:)%format    = -1

--- a/mpp/include/mpp_util.inc
+++ b/mpp/include/mpp_util.inc
@@ -44,7 +44,7 @@
     use shr_log_mod, only : shr_log_getLogUnit
     integer :: stdout
     call shr_log_getLogUnit(stdout)
-    ! hardcoded 1024 should be same as _MAX_FILE_UNITS 
+    ! hardcoded 1024 should be same as _MAX_FILE_UNITS
     if(stdout < -1024 ) then
        call mpp_error(FATAL,'=>mpp_util.inc: ATTEMPT TO SET stdout to a unit outside of allowed range')
     endif


### PR DESCRIPTION
**Description**
This PR adjusts string lengths to be longer than 128 characters and 
modifies the get_time_string function to allow for the use of % signs in
cesm test names.   This allows us to run tests with MOM using the cesm
testing mechanism with long compset names. 

Fixes # (issue)

**How Has This Been Tested?**
I ran test ERS.ne30pg3_t232.1850_CAM60_CLM50%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_SWAV.derecho_intel.allactive-defaultio

This test will fail in mom - first because the filename string length was hardcoded to 128 characters and second because fms assumes that the % sign will not be used in filenames.  

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] `make distcheck` passes

