### PR TITLE
Updates needed for MARBL

### DIFF
--- a/affinity/affinity.c
+++ b/affinity/affinity.c
@@ -48,7 +48,7 @@
  * gettid function for systems that do not have this function (e.g. on Mac OS.)
  */
 #ifndef HAVE_GETTID
-static pid_t gettid(void)
+pid_t gettid(void)
 {
 #if defined(__APPLE__)
   uint64_t tid64;

--- a/diag_manager/diag_data.F90
+++ b/diag_manager/diag_data.F90
@@ -64,7 +64,7 @@ use platform_mod
   PUBLIC
 
   ! Specify storage limits for fixed size tables used for pointers, etc.
-  INTEGER, PARAMETER :: MAX_FIELDS_PER_FILE = 300 !< Maximum number of fields per file.
+  INTEGER, PARAMETER :: MAX_FIELDS_PER_FILE = 500 !< Maximum number of fields per file.
   INTEGER, PARAMETER :: DIAG_OTHER = 0
   INTEGER, PARAMETER :: DIAG_OCEAN = 1
   INTEGER, PARAMETER :: DIAG_ALL   = 2


### PR DESCRIPTION
**Description**

1. Intel compiler complains about gettid being declared a static when building the standalone MOM driver (no impact on CESM)
2. Increase MAX_FIELDS_PER_FILE to 500 because every MARBL diagnostic is added to a single history file when running the test suite, and that adds up to ~475 total fields in the h.bgc.z stream and 405 fields in the h.bgc.native stream

Fixes # (issue)

**How Has This Been Tested?**
I have run `aux_mom` and `aux_mom_MARBL`, and also ensured that the single column tests in `components/mom/standalone/examples/single_column_MARBL` build and run successfully

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [ ] `make distcheck` passes

