### PR TITLE
fix obliquity input test in astronomy.F90

### DIFF
--- a/astronomy/astronomy.F90
+++ b/astronomy/astronomy.F90
@@ -636,7 +636,7 @@ real, intent(in) :: per_in !< Longitude of perihelion with respect to autumnal
       if (ecc_in < 0.0 .or. ecc_in > 0.99) &
         call error_mesg ('astronomy_mod', &
                       'ecc must be between 0 and 0.99', FATAL)
-      if (obliq_in < -90.0 .or. obliq > 90.0) &
+      if (obliq_in < -90.0 .or. obliq_in > 90.0) &
         call error_mesg ('astronomy_mod', &
                 'obliquity must be between -90. and 90. degrees', FATAL)
       if (per_in < 0.0 .or. per_in > 360.0) &


### PR DESCRIPTION
**Description**
In one input check it said `obliq` in stead of `obliq_in`.



also, to answer the comment with:
`QUESTION : ARE THESE THE RIGHT LIMITS ???`

I am not sure if the limits should be based on the physically possible values, or on the values for Earth specifically.

Earth's orbital eccentricity has varied between 0 and 0.067 for the past 100 Myr, so maybe a test more like 0 to 0.1 would be more suited?

Earth's obliquity has varied from 22° to 24.5° in the same time period, so a better range to check would be something like 10° to 40°? A negative value would not make sense, I think. It should be between 0° and 180°.

Earth's longitude of perihelion with respect to the moving equinox rotates and librates, so it does vary between 0° and 360°.

I could implement these changes in this pull request if desired.

These are the equivalent lines in `shr_orb_mod.F90`:
 https://github.com/ESCOMP/CDEPS/blob/8197f05ef2549d3c53e4050c9821a683e2728bab/share/shr_orb_mod.F90#L27-L33

Fixes # (issue)

**How Has This Been Tested?**
no testing, used github edit feature because I just came across the typo.


**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] `make distcheck` passes

