### PR TITLE
Fix combining of partitioned netcdf files for overriden history files

### DIFF
--- a/fms2_io/netcdf_io.F90
+++ b/fms2_io/netcdf_io.F90
@@ -702,7 +702,12 @@ subroutine append_to_filepath_list(filepath, filepath_list)
     call string_copy(filepath_list%path, trim(filepath))
   else
     current => filepath_list
-    do while (associated(current%next))
+    do
+      ! If file is already in the list, return. This happens when new_file_freq (e.g., daily) 
+      ! is more frequent than the date suffix (e.g., %4yr-%2mo), leading to overriding the file.
+      if (string_compare(current%path, trim(filepath))) return
+      ! If we reach the end of the list, exit the loop to add the new file.
+      if (.not. associated(current%next)) exit
       current => current%next
     enddo
     allocate(current%next)


### PR DESCRIPTION
If the `new_file_freq` of a history stream is more frequent than the most frequent datestamp suffix in filename (e.g., `'daily'` and `'%2mo'`), that files gets overriden (~30 times over a month), meaning that it gets closed multiple times. With this PR, a file gets appended to `filepath_list` (the linked list of files to combine) only once even if it gets closed (overriden) multipe times. 

Note for @mnlevy1981 : This edge case was caught in aux_mom MARBL tests because the `daily` `bgc` files do not have the day stamp in the file name.
