### PR TITLE
Append ensemble suffixes right after .mom6 substring in history files

### DIFF
--- a/fms2_io/fms_io_utils.F90
+++ b/fms2_io/fms_io_utils.F90
@@ -804,12 +804,20 @@ subroutine get_instance_filename(name_in,name_out)
   character(len=*), intent(inout) :: name_out !< name_in with the filename_appendix
 
   integer :: length !< Length of name_in
-  integer :: i !< no description
+  integer :: i !< Position index
+  integer :: mom6_pos !< Position of .mom6 substring
 
   length = len_trim(name_in)
   name_out = name_in(1:length)
 
   if(len_trim(filename_appendix) > 0) then
+     !< If .mom6 is in the filename, add the appendix right after it
+     mom6_pos = index(trim(name_in), ".mom6", back=.true.)
+     if (mom6_pos .ne. 0) then
+         name_out = name_in(1:mom6_pos+4)//trim(filename_appendix)//name_in(mom6_pos+5:length)
+         return
+     endif
+
      !< If .tileXX is in the filename add the appendix before it
      if (has_domain_tile_string(name_in)) then
          i = index(trim(name_in), ".tile", back=.true.)


### PR DESCRIPTION
In FMS, ensemble suffix (`_0001`,  `_0002`) gets appended to the end of the diagnostics file names. This PR changes that by instead appending the ensemble suffix to the last occurence of `.mom6`suffix (if it exists) in the file name, so as to make multi-instance mom6 history files in line with the rest of CESM.

This PR is part of a series of PRs to fix various interrelated restart/multi-instance/hybrid run issues alongside 
https://github.com/NCAR/MOM6/pull/409
https://github.com/ESCOMP/MOM_interface/pull/311
https://github.com/ESMCI/cime/pull/4944